### PR TITLE
Only set host if present?

### DIFF
--- a/lib/imgproxy/url_adapters/shrine.rb
+++ b/lib/imgproxy/url_adapters/shrine.rb
@@ -18,8 +18,8 @@ module Imgproxy
 
       def url(image)
         opts = {}
-        opts = { host: @host } if @host
-        image.url(**opts) 
+        opts[:host] = @host if @host
+        image.url(opts) 
       end
     end
   end

--- a/lib/imgproxy/url_adapters/shrine.rb
+++ b/lib/imgproxy/url_adapters/shrine.rb
@@ -17,7 +17,7 @@ module Imgproxy
       end
 
       def url(image)
-        image.url(host: @host)
+        image.url(host: @host) if @host
       end
     end
   end

--- a/lib/imgproxy/url_adapters/shrine.rb
+++ b/lib/imgproxy/url_adapters/shrine.rb
@@ -17,7 +17,9 @@ module Imgproxy
       end
 
       def url(image)
-        image.url(host: @host) if @host
+        opts = {}
+        opts = { host: @host } if @host
+        image.url(**opts) 
       end
     end
   end


### PR DESCRIPTION
At the moment, if host option already set on Shrine and one don't supply a host parameter to imgproxy it overwrites it to nil causing shrine to use default s3 URL instead of the custom host.

```rb
image.image.url(host: nil)
=> "https://foobar.s3.us-east-2.amazonaws.com/blablabla..."
image.image.url
=> "https://custom.foobar.com/blablabla..."
```