### PR TITLE
Add option to use Base64 encoded url

### DIFF
--- a/lib/imgproxy.rb
+++ b/lib/imgproxy.rb
@@ -22,6 +22,7 @@ module Imgproxy
     #     config.hex_key = "your_key"
     #     config.hex_salt = "your_salt"
     #     config.use_short_options = true
+    #     config.use_base64_encode = false
     #   end
     #
     # @yieldparam config [Config]

--- a/lib/imgproxy/builder.rb
+++ b/lib/imgproxy/builder.rb
@@ -35,8 +35,14 @@ module Imgproxy
     #   the configured URL adapters
     # @see Imgproxy.url_for
     def url_for(image)
-      path = [*processing_options, "plain", url(image)].join("/")
-      path = "#{path}@#{@options[:format]}" if @options[:format]
+      if use_base64_encoded_url
+        encoded_url = Base64.urlsafe_encode64(url(image)).tr("=", "").scan(/.{1,16}/).join("/")
+        path = [*processing_options, encoded_url].join("/")
+        path = "#{path}.#{@options[:format]}" if @options[:format]
+      else
+        path = [*processing_options, "plain", url(image)].join("/")
+        path = "#{path}@#{@options[:format]}" if @options[:format]
+      end
 
       signature = sign_path(path)
 
@@ -121,6 +127,10 @@ module Imgproxy
 
     def signature_size
       config.signature_size
+    end
+
+    def use_base64_encoded_url
+      config.use_base64_encode
     end
 
     def config

--- a/lib/imgproxy/config.rb
+++ b/lib/imgproxy/config.rb
@@ -16,10 +16,14 @@ module Imgproxy
     #   (`rs` for `resize`, `g` for `gravity`, etc).
     #   Defaults to true
     attr_accessor :use_short_options
+    # @return [Boolean] use base64 encoding for urls
+    #   Defaults to false
+    attr_accessor :use_base64_encode
 
     def initialize
       self.signature_size = 32
       self.use_short_options = true
+      self.use_base64_encode = false
     end
 
     # Decodes hex-encoded key and sets it to {#key}


### PR DESCRIPTION
This adds an option to use encoded urls as per [Base64 encoded](https://docs.imgproxy.net/#/generating_the_url_advanced?id=base64-encoded).
The default for the new option is false to maintain old behaviour and be opt in.