### PR TITLE
Add missing option 'filename'

### DIFF
--- a/lib/imgproxy/options.rb
+++ b/lib/imgproxy/options.rb
@@ -42,6 +42,7 @@ module Imgproxy
       preset:        Imgproxy::OptionsExtractors::Array.new(:preset),
       cachebuster:   Imgproxy::OptionsExtractors::String.new(:cachebuster),
       format:        Imgproxy::OptionsExtractors::String.new(:format),
+      filename:      Imgproxy::OptionsExtractors::String.new(:filename),
       video_thumbnail_second: Imgproxy::OptionsExtractors::Integer.new(:video_thumbnail_second),
     }.freeze
 

--- a/lib/imgproxy/options_aliases.rb
+++ b/lib/imgproxy/options_aliases.rb
@@ -26,5 +26,6 @@ module Imgproxy
     preset: :pr,
     cachebuster: :cb,
     video_thumbnail_second: :vts,
+    filename: :fn
   }.freeze
 end


### PR DESCRIPTION
Option 'filename' (https://github.com/imgproxy/imgproxy/blob/master/docs/generating_the_url_advanced.md#filename) was missing from Options hash