### PR TITLE
Add support for short Wasabi URLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ end
 - **base64_encode_urls** (`IMGPROXY_BASE64_ENCODE_URLS`) - Encode source URLs to base64. Default: false.
 - **always_escape_plain_urls** (`IMGPROXY_ALWAYS_ESCAPE_PLAIN_URLS`) - Always escape plain source URLs even when ones don't need to be escaped. Default: false.
 - **use_s3_urls** (`IMGPROXY_USE_S3_URLS`) - Use `s3://...` source URLs for Active Storage and Shrine attachments stored in Amazon S3. Default: false.
+- **use_wasabi_urls** (`IMGPROXY_USE_WASABI_URLS`) - Use `"https://s3.wasabisys.com/` source URLs for Active Storage attachments stored in Wasabi compatible S3 storage. Default: false.
 - **use_gcs_urls** (`IMGPROXY_USE_GCS_URLS`) - Use `gs://...` source URLs for Active Storage and Shrine attachments stored in Google Cloud Storage. Default: false.
 - **gcs_bucket** (`IMGPROXY_GCS_BUCKET`) - Google Cloud Storage bucket name. Default: `nil`.
 - **shrine_host** (`IMGPROXY_SHRINE_HOST`) - Shrine host for locally stored files.

--- a/lib/imgproxy/config.rb
+++ b/lib/imgproxy/config.rb
@@ -60,6 +60,7 @@ module Imgproxy
       base64_encode_urls: false,
       always_escape_plain_urls: false,
       use_s3_urls: false,
+      use_wasabi_urls: false,
       use_gcs_urls: false,
       gcs_bucket: nil,
       shrine_host: nil,

--- a/lib/imgproxy/url_adapters/active_storage.rb
+++ b/lib/imgproxy/url_adapters/active_storage.rb
@@ -15,6 +15,7 @@ module Imgproxy
       end
 
       def url(image)
+        return wasabi_url(image) if use_wasabi_url(image)
         return s3_url(image) if use_s3_url(image)
         return gcs_url(image) if use_gcs_url(image)
 
@@ -29,6 +30,14 @@ module Imgproxy
 
       def use_s3_url(image)
         config.use_s3_urls && image.service.is_a?(::ActiveStorage::Service::S3Service)
+      end
+
+      def wasabi_url(image)
+        "https://s3.wasabisys.com/#{image.service.bucket.name}/#{image.key}"
+      end
+
+      def use_wasabi_url(image)
+        config.use_wasabi_urls && image.service.is_a?(::ActiveStorage::Service::S3Service)
       end
 
       def gcs_url(image)

--- a/lib/imgproxy/url_adapters/active_storage.rb
+++ b/lib/imgproxy/url_adapters/active_storage.rb
@@ -29,7 +29,7 @@ module Imgproxy
       end
 
       def use_s3_url(image)
-        config.use_s3_urls && image.service.is_a?(::ActiveStorage::Service::S3Service)
+        config.use_s3_urls && (image.service.is_a?(::ActiveStorage::Service::S3Service) || image.service.is_a?(::ActiveStorage::Service::MirrorService))
       end
 
       def wasabi_url(image)
@@ -37,7 +37,7 @@ module Imgproxy
       end
 
       def use_wasabi_url(image)
-        config.use_wasabi_urls && image.service.is_a?(::ActiveStorage::Service::S3Service)
+        config.use_wasabi_urls && (image.service.is_a?(::ActiveStorage::Service::S3Service) || image.service.is_a?(::ActiveStorage::Service::MirrorService))
       end
 
       def gcs_url(image)

--- a/lib/imgproxy/url_adapters/active_storage.rb
+++ b/lib/imgproxy/url_adapters/active_storage.rb
@@ -33,7 +33,7 @@ module Imgproxy
       end
 
       def wasabi_url(image)
-        "https://s3.wasabisys.com/#{image.service.bucket.name}/#{image.key}"
+        "https://s3.wasabisys.com/#{image.service.primary.bucket.name}/#{image.key}"
       end
 
       def use_wasabi_url(image)


### PR DESCRIPTION
Wasabi is an inexpensive S3 compatible AWS competitor. However, it seems they don't support the direct `s3://bucket/object_key` access. 
This PR allows the developer to configure an optional `IMGPROXY_USE_WASABI_URLS` parameter to use the Wasabi structure of `s3.wasabisys.com/bucket/key`

As an interesting side note I did this b/c my application is using proxy urls by default, so the default `Rails.application.routes.url_helpers.url_for(image)` in `url_adapters/active_storage` `def url` was returning a proxy URL. 