### PR TITLE
Adds expires to supported options

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ builder.url_for("http://images.example.com/images/image2.jpg")
 - [filename](https://docs.imgproxy.net/#/generating_the_url_advanced?id=filename)
 - [format](https://docs.imgproxy.net/#/generating_the_url_advanced?id=format)
 - [return_attachment](https://docs.imgproxy.net/#/generating_the_url_advanced?id=return-attachment)
+- [expires](https://docs.imgproxy.net/#/generating_the_url?id=expires)
 
 _See [imgproxy URL format guide](https://docs.imgproxy.net/#/generating_the_url_advanced?id=processing-options) for more info._
 

--- a/lib/imgproxy.rb
+++ b/lib/imgproxy.rb
@@ -101,6 +101,7 @@ module Imgproxy
     # @option options [String] :filename
     # @option options [String] :format
     # @option options [Boolean] :return_attachment
+    # @option options [Integer] :expires
     # @option options [Boolean] :use_short_options
     # @option options [Boolean] :base64_encode_urls
     # @option options [Boolean] :escape_plain_url

--- a/lib/imgproxy/options.rb
+++ b/lib/imgproxy/options.rb
@@ -65,6 +65,7 @@ module Imgproxy
       filename:               Imgproxy::OptionsCasters::String,
       format:                 Imgproxy::OptionsCasters::String,
       return_attachment:      Imgproxy::OptionsCasters::Bool,
+      expires:                Imgproxy::OptionsCasters::Integer,
     }.freeze
 
     META = %i[size resize adjust].freeze

--- a/lib/imgproxy/options_aliases.rb
+++ b/lib/imgproxy/options_aliases.rb
@@ -40,5 +40,6 @@ module Imgproxy
     auto_rotate: :ar,
     filename: :fn,
     return_attachment: :att,
+    expires: :exp,
   }.freeze
 end

--- a/spec/imgproxy_spec.rb
+++ b/spec/imgproxy_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe Imgproxy do
         filename: "the_image.jpg",
         format: :webp,
         return_attachment: true,
+        expires: Time.at(4810374983),
       }
     end
 
@@ -166,7 +167,8 @@ RSpec.describe Imgproxy do
       "scp:0/"\
       "ar:1/"\
       "fn:the_image.jpg/"\
-      "att:1"
+      "att:1/"\
+      "exp:4810374983"
     end
 
     let(:casted_options_full) do
@@ -210,7 +212,8 @@ RSpec.describe Imgproxy do
       "strip_color_profile:0/"\
       "auto_rotate:1/"\
       "filename:the_image.jpg/"\
-      "return_attachment:1"
+      "return_attachment:1/"\
+      "expires:4810374983"
     end
     # rubocop: enable Layout/LineEndStringConcatenationIndentation
 
@@ -587,18 +590,6 @@ RSpec.describe Imgproxy do
 
         it "signs the URL with truncated signature" do
           expect(url).to start_with "http://imgproxy.test/6PuaY-c/"
-        end
-      end
-
-      context "with expiration" do
-        let(:options) { { width: 100, height: 100, expires: Time.at(4810374983) } }
-        let(:casted_options) { "s:100:100/exp:4810374983" }
-
-        it "sets expiration" do
-          expect(url).to eq(
-            "http://imgproxy.test/7ZYBNHeKGmkZd8ned9ei5b3QVNq5_cmAb4yz77j8vaE/#{casted_options}/"\
-            "plain/https://images.test/image.jpg",
-          )
         end
       end
     end

--- a/spec/imgproxy_spec.rb
+++ b/spec/imgproxy_spec.rb
@@ -589,6 +589,18 @@ RSpec.describe Imgproxy do
           expect(url).to start_with "http://imgproxy.test/6PuaY-c/"
         end
       end
+
+      context "with expiration" do
+        let(:options) { { width: 100, height: 100, expires: Time.at(4810374983) } }
+        let(:casted_options) { "s:100:100/exp:4810374983" }
+
+        it "sets expiration" do
+          expect(url).to eq(
+            "http://imgproxy.test/7ZYBNHeKGmkZd8ned9ei5b3QVNq5_cmAb4yz77j8vaE/#{casted_options}/"\
+            "plain/https://images.test/image.jpg",
+          )
+        end
+      end
     end
   end
 


### PR DESCRIPTION
I started working on this because I didn't realize that you can just pass through parameters that aren't explicitly parsed by this library, but the benefit of this PR is that it allows using Time objects directly instead of needing to convert to an integer. It also now explicitly says in the README that `expires` is supported.