### PR TITLE
Add custom services configuration

### DIFF
--- a/lib/imgproxy.rb
+++ b/lib/imgproxy.rb
@@ -1,6 +1,5 @@
 require "imgproxy/version"
-require "imgproxy/config"
-require "imgproxy/builder"
+require "imgproxy/service"
 
 require "imgproxy/extensions/active_storage"
 require "imgproxy/extensions/shrine"
@@ -8,11 +7,28 @@ require "imgproxy/extensions/shrine"
 # @see Imgproxy::ClassMethods
 module Imgproxy
   class << self
-    # Imgproxy config
+    # Get required service for Imgproxy
     #
-    # @return [Config]
+    # @param name [Symbol]
+    # @return [Service]
+    def service(name)
+      @services ||= {}
+      @services[name] ||= Imgproxy::Service.new(name)
+    end
+
+    # @see Imgproxy::Service#config
     def config
-      @config ||= Imgproxy::Config.new
+      service(:default).config
+    end
+
+    # @see Imgproxy::Service#url_for
+    def url_for(*args, **kwargs)
+      service(:default).url_for(*args, **kwargs)
+    end
+
+    # @see Imgproxy::Service#info_url_for
+    def info_url_for(*args, **kwargs)
+      service(:default).info_url_for(*args, **kwargs)
     end
 
     # Yields Imgproxy config
@@ -26,101 +42,9 @@ module Imgproxy
     #
     # @yieldparam config [Config]
     # @return [Config]
-    def configure
-      yield config
-      config
-    end
-
-    # Genrates imgproxy URL
-    #
-    #   Imgproxy.url_for(
-    #     "http://images.example.com/images/image.jpg",
-    #     width: 500,
-    #     height: 400,
-    #     resizing_type: :fill,
-    #     sharpen: 0.5,
-    #     gravity: {
-    #       type: :soea,
-    #       x_offset: 10,
-    #       y_offset: 5,
-    #     },
-    #     crop: {
-    #       width: 2000,
-    #       height: 1000,
-    #       gravity: {
-    #         type: :nowe,
-    #         x_offset: 20,
-    #         y_offset: 30,
-    #       },
-    #     },
-    #   )
-    #
-    # @return [String] imgproxy URL
-    # @param [String,URI, Object] image Source image URL or object applicable for
-    #   the configured URL adapters
-    # @param [Hash] options Processing options
-    # @option options [Hash|Array|String] :resize
-    # @option options [Hash|Array|String] :size
-    # @option options [String] :resizing_type
-    # @option options [String] :resizing_algorithm supported only by imgproxy pro
-    # @option options [Integer] :width
-    # @option options [Integer] :height
-    # @option options [Float] :dpr
-    # @option options [Boolean] :enlarge
-    # @option options [Hash|Array|Boolean|String] :extend
-    # @option options [Hash|Array|String] :gravity
-    # @option options [Hash|Array|String] :crop
-    # @option options [Array] :padding
-    # @option options [Hash|Array|String] :trim
-    # @option options [Integer] :rotate
-    # @option options [Integer] :quality
-    # @option options [Integer] :max_bytes
-    # @option options [Array|String] :background
-    # @option options [Float] :background_alpha supported only by imgproxy pro
-    # @option options [Hash|Array|String] :adjust
-    # @option options [Integer] :brightness supported only by imgproxy pro
-    # @option options [Float] :contrast supported only by imgproxy pro
-    # @option options [Float] :saturation supported only by imgproxy pro
-    # @option options [Float] :blur
-    # @option options [Float] :sharpen
-    # @option options [Integer] :pixelate supported only by imgproxy pro
-    # @option options [String] :unsharpening supported only by imgproxy pro
-    # @option options [Hash|Array|Float|String] :watermark
-    # @option options [String] :watermark_url supported only by imgproxy pro
-    # @option options [String] :style supported only by imgproxy pro
-    # @option options [Hash|Array|String] :jpeg_options supported only by imgproxy pro
-    # @option options [Hash|Array|String] :png_options supported only by imgproxy pro
-    # @option options [Hash|Array|String] :gif_options supported only by imgproxy pro
-    # @option options [Integer] :page supported only by imgproxy pro
-    # @option options [Integer] :video_thumbnail_second supported only by imgproxy pro
-    # @option options [Array] :preset
-    # @option options [String] :cachebuster
-    # @option options [Boolean] :strip_metadata
-    # @option options [Boolean] :strip_color_profile
-    # @option options [Boolean] :auto_rotate
-    # @option options [String] :filename
-    # @option options [String] :format
-    # @option options [Boolean] :use_short_options
-    # @option options [Boolean] :base64_encode_urls
-    # @option options [Boolean] :escape_plain_url
-    # @see https://docs.imgproxy.net/#/generating_the_url_advanced?id=processing-options
-    #   Available imgproxy URL processing options and their arguments
-    def url_for(image, options = {})
-      Imgproxy::Builder.new(options).url_for(image)
-    end
-
-    # Genrates imgproxy info URL. Supported only by imgproxy pro
-    #
-    #   Imgproxy.info_url_for("http://images.example.com/images/image.jpg")
-    #
-    # @return [String] imgproxy info URL
-    # @param [String,URI, Object] image Source image URL or object applicable for
-    #   the configured URL adapters
-    # @param [Hash] options Processing options
-    # @option options [Boolean] :base64_encode_urls
-    # @option options [Boolean] :escape_plain_url
-    def info_url_for(image, options = {})
-      Imgproxy::Builder.new(options).info_url_for(image)
+    def configure(service_name = :default)
+      yield service(service_name).config
+      service(service_name).config
     end
 
     # Extends +ActiveStorage::Blob+ with {Imgproxy::Extensions::ActiveStorage.imgproxy_url} method

--- a/lib/imgproxy/builder.rb
+++ b/lib/imgproxy/builder.rb
@@ -20,7 +20,8 @@ module Imgproxy
   class Builder
     # @param [Hash] options Processing options
     # @see Imgproxy.url_for
-    def initialize(options = {})
+    def initialize(config: Imgproxy.config, **options)
+      @config = config
       options = options.dup
 
       extract_builder_options(options)
@@ -39,7 +40,7 @@ module Imgproxy
       path = [*processing_options, url(image, ext: @format)].join("/")
       signature = sign_path(path)
 
-      File.join(Imgproxy.config.endpoint.to_s, signature, path)
+      File.join(config.endpoint.to_s, signature, path)
     end
 
     # Genrates imgproxy info URL
@@ -52,10 +53,12 @@ module Imgproxy
       path = url(image)
       signature = sign_path(path)
 
-      File.join(Imgproxy.config.endpoint.to_s, "info", signature, path)
+      File.join(config.endpoint.to_s, "info", signature, path)
     end
 
     private
+
+    attr_reader :config
 
     NEED_ESCAPE_RE = /[@?% ]|[^\p{Ascii}]/.freeze
 
@@ -127,10 +130,6 @@ module Imgproxy
 
     def signature_size
       config.signature_size
-    end
-
-    def config
-      Imgproxy.config
     end
 
     def not_nil_or(value, fallback)

--- a/lib/imgproxy/service.rb
+++ b/lib/imgproxy/service.rb
@@ -1,0 +1,112 @@
+require "imgproxy/config"
+require "imgproxy/builder"
+
+module Imgproxy
+  # Imgproxy service
+  #
+  class Service
+    # @param name [Symbol]
+    def initialize(name)
+      @name = name
+    end
+
+    # Imgproxy config
+    #
+    # @return [Config]
+    def config
+      @config ||= Imgproxy::Config.new
+    end
+
+    # Genrates imgproxy URL
+    #
+    #   Imgproxy.url_for(
+    #     "http://images.example.com/images/image.jpg",
+    #     width: 500,
+    #     height: 400,
+    #     resizing_type: :fill,
+    #     sharpen: 0.5,
+    #     gravity: {
+    #       type: :soea,
+    #       x_offset: 10,
+    #       y_offset: 5,
+    #     },
+    #     crop: {
+    #       width: 2000,
+    #       height: 1000,
+    #       gravity: {
+    #         type: :nowe,
+    #         x_offset: 20,
+    #         y_offset: 30,
+    #       },
+    #     },
+    #   )
+    #
+    # @return [String] imgproxy URL
+    # @param [String,URI, Object] image Source image URL or object applicable for
+    #   the configured URL adapters
+    # @param [Hash] options Processing options
+    # @option options [Hash|Array|String] :resize
+    # @option options [Hash|Array|String] :size
+    # @option options [String] :resizing_type
+    # @option options [String] :resizing_algorithm supported only by imgproxy pro
+    # @option options [Integer] :width
+    # @option options [Integer] :height
+    # @option options [Float] :dpr
+    # @option options [Boolean] :enlarge
+    # @option options [Hash|Array|Boolean|String] :extend
+    # @option options [Hash|Array|String] :gravity
+    # @option options [Hash|Array|String] :crop
+    # @option options [Array] :padding
+    # @option options [Hash|Array|String] :trim
+    # @option options [Integer] :rotate
+    # @option options [Integer] :quality
+    # @option options [Integer] :max_bytes
+    # @option options [Array|String] :background
+    # @option options [Float] :background_alpha supported only by imgproxy pro
+    # @option options [Hash|Array|String] :adjust
+    # @option options [Integer] :brightness supported only by imgproxy pro
+    # @option options [Float] :contrast supported only by imgproxy pro
+    # @option options [Float] :saturation supported only by imgproxy pro
+    # @option options [Float] :blur
+    # @option options [Float] :sharpen
+    # @option options [Integer] :pixelate supported only by imgproxy pro
+    # @option options [String] :unsharpening supported only by imgproxy pro
+    # @option options [Hash|Array|Float|String] :watermark
+    # @option options [String] :watermark_url supported only by imgproxy pro
+    # @option options [String] :style supported only by imgproxy pro
+    # @option options [Hash|Array|String] :jpeg_options supported only by imgproxy pro
+    # @option options [Hash|Array|String] :png_options supported only by imgproxy pro
+    # @option options [Hash|Array|String] :gif_options supported only by imgproxy pro
+    # @option options [Integer] :page supported only by imgproxy pro
+    # @option options [Integer] :video_thumbnail_second supported only by imgproxy pro
+    # @option options [Array] :preset
+    # @option options [String] :cachebuster
+    # @option options [Boolean] :strip_metadata
+    # @option options [Boolean] :strip_color_profile
+    # @option options [Boolean] :auto_rotate
+    # @option options [String] :filename
+    # @option options [String] :format
+    # @option options [Boolean] :use_short_options
+    # @option options [Boolean] :base64_encode_urls
+    # @option options [Boolean] :escape_plain_url
+    # @see https://docs.imgproxy.net/#/generating_the_url_advanced?id=processing-options
+    #   Available imgproxy URL processing options and their arguments
+    def url_for(image, options = {})
+      Imgproxy::Builder.new(**options, config: config).url_for(image)
+    end
+
+    # Genrates imgproxy info URL. Supported only by imgproxy pro
+    #
+    #   Imgproxy.info_url_for("http://images.example.com/images/image.jpg")
+    #
+    # @return [String] imgproxy info URL
+    # @param [String,URI, Object] image Source image URL or object applicable for
+    #   the configured URL adapters
+    # @param [Hash] options Processing options
+    # @option options [Boolean] :base64_encode_urls
+    # @option options [Boolean] :escape_plain_url
+    def info_url_for(image, options = {})
+      Imgproxy::Builder.new(**options, config: config).info_url_for(image)
+    end
+  end
+end

--- a/spec/imgproxy_spec.rb
+++ b/spec/imgproxy_spec.rb
@@ -585,6 +585,27 @@ RSpec.describe Imgproxy do
         end
       end
     end
+
+    describe "different services" do
+      before do
+        described_class.configure(:large_files) do |c|
+          c.endpoint = "http://large-files.test/"
+        end
+
+        described_class.configure(:small_files) do |c|
+          c.endpoint = "http://small-files.test/"
+        end
+      end
+
+      it "returns different urls for different services" do
+        large_files_url = described_class.service(:large_files).url_for(src_url, options)
+        small_files_url = described_class.service(:small_files).url_for(src_url, options)
+
+        expect(large_files_url).to start_with "http://large-files.test/unsafe/"
+        expect(small_files_url).to start_with "http://small-files.test/unsafe/"
+        expect(url).to start_with "http://imgproxy.test/unsafe/"
+      end
+    end
   end
 
   describe ".info_url_for" do
@@ -643,6 +664,27 @@ RSpec.describe Imgproxy do
           expect(described_class.info_url_for(src_url)).to start_with(
             "http://imgproxy.test/info/1KMMwfg/",
           )
+        end
+      end
+
+      describe "different services" do
+        before do
+          described_class.configure(:large_files) do |c|
+            c.endpoint = "http://large-files.test/"
+          end
+
+          described_class.configure(:small_files) do |c|
+            c.endpoint = "http://small-files.test/"
+          end
+        end
+
+        it "returns different urls for different services" do
+          large_files_url = described_class.service(:large_files).info_url_for(src_url, options)
+          small_files_url = described_class.service(:small_files).info_url_for(src_url, options)
+
+          expect(large_files_url).to start_with "http://large-files.test/info/"
+          expect(small_files_url).to start_with "http://small-files.test/info/"
+          expect(url).to start_with "http://imgproxy.test/info/"
         end
       end
     end


### PR DESCRIPTION
On a project we might want to use a few instances of imgproxy with different endpoints, keys, secrets, etc. This commit adds an ability to have multiple configs for different services.

- [x] Keep existing functionality and signatures as they are
- [x] Add tests
