### PR TITLE
Add custom services

### DIFF
--- a/lib/imgproxy/builder.rb
+++ b/lib/imgproxy/builder.rb
@@ -23,6 +23,8 @@ module Imgproxy
     def initialize(options = {})
       options = options.dup
 
+      @config = Imgproxy.config(options.delete(:service))
+
       extract_builder_options(options)
 
       @options = Imgproxy::Options.new(options)
@@ -39,7 +41,7 @@ module Imgproxy
       path = [*processing_options, url(image, ext: @format)].join("/")
       signature = sign_path(path)
 
-      File.join(Imgproxy.config.endpoint.to_s, signature, path)
+      File.join(config.endpoint.to_s, signature, path)
     end
 
     # Genrates imgproxy info URL
@@ -52,10 +54,12 @@ module Imgproxy
       path = url(image)
       signature = sign_path(path)
 
-      File.join(Imgproxy.config.endpoint.to_s, "info", signature, path)
+      File.join(config.endpoint.to_s, "info", signature, path)
     end
 
     private
+
+    attr_reader :config
 
     NEED_ESCAPE_RE = /[@?% ]|[^\p{Ascii}]/.freeze
 
@@ -127,10 +131,6 @@ module Imgproxy
 
     def signature_size
       config.signature_size
-    end
-
-    def config
-      Imgproxy.config
     end
 
     def not_nil_or(value, fallback)

--- a/lib/imgproxy/configs.rb
+++ b/lib/imgproxy/configs.rb
@@ -1,0 +1,37 @@
+require "anyway_config"
+require "imgproxy/config"
+
+module Imgproxy
+  # Imgproxy configs wrapper for different services
+  #
+  class Configs < Anyway::Config
+    config_name :imgproxy
+
+    attr_config(services: [])
+
+    on_load :fill_services_override
+
+    attr_reader :configs
+
+    # Returns config by service name
+    #
+    # @param service_name [Symbol]
+    # @return [Config]
+    def [](service_name)
+      configs[service_name] ||= Config.new
+    end
+
+    private
+
+    def fill_services_override
+      @configs = {}
+      services.each do |service|
+        next unless service["name"]
+
+        @configs[service["name"].to_sym] = Config.new(service)
+      end
+
+      @configs[:default] = Config.new
+    end
+  end
+end

--- a/lib/imgproxy/url_adapters/active_storage.rb
+++ b/lib/imgproxy/url_adapters/active_storage.rb
@@ -8,6 +8,10 @@ module Imgproxy
     #
     #   Imgproxy.url_for(user.avatar)
     class ActiveStorage
+      def initialize(service_name)
+        @service_name = service_name
+      end
+
       def applicable?(image)
         image.is_a?(::ActiveStorage::Attached::One) ||
           image.is_a?(::ActiveStorage::Attachment) ||
@@ -22,6 +26,8 @@ module Imgproxy
       end
 
       private
+
+      attr_reader :service_name
 
       def s3_url(image)
         "s3://#{service(image).bucket.name}/#{image.key}"
@@ -50,7 +56,7 @@ module Imgproxy
       end
 
       def config
-        Imgproxy.config
+        Imgproxy.config(service_name)
       end
     end
   end

--- a/lib/imgproxy/url_adapters/shrine.rb
+++ b/lib/imgproxy/url_adapters/shrine.rb
@@ -8,6 +8,12 @@ module Imgproxy
     #
     #   Imgproxy.url_for(user.avatar)
     class Shrine
+      attr_reader :service_name
+
+      def initialize(service_name)
+        @service_name = service_name
+      end
+
       def applicable?(image)
         image.is_a?(::Shrine::UploadedFile)
       end
@@ -16,7 +22,7 @@ module Imgproxy
         return s3_url(image) if use_s3_url(image)
 
         opts = {}
-        opts[:host] = Imgproxy.config.shrine_host if Imgproxy.config.shrine_host
+        opts[:host] = config.shrine_host if config.shrine_host
         image.url(**opts)
       end
 
@@ -28,8 +34,12 @@ module Imgproxy
       end
 
       def use_s3_url(image)
-        Imgproxy.config.use_s3_urls &&
+        config.use_s3_urls &&
           image.storage.is_a?(::Shrine::Storage::S3)
+      end
+
+      def config
+        Imgproxy.config(service_name)
       end
     end
   end

--- a/spec/url_adapters/shrine_spec.rb
+++ b/spec/url_adapters/shrine_spec.rb
@@ -101,4 +101,16 @@ RSpec.describe Imgproxy::UrlAdapters::Shrine do
       end
     end
   end
+
+  describe "for custom service" do
+    before do
+      Imgproxy.config(:custom).shrine_host = "http://custom.com"
+      Imgproxy.extend_shrine!
+    end
+
+    it "builds URL for Shrine::UploadedFile" do
+      expect(Imgproxy.url_for(uploaded_file, service: :custom)).to end_with \
+        "/plain/#{uploaded_file.url(host: 'http://custom.com')}"
+    end
+  end
 end


### PR DESCRIPTION
Add custom service configuration that allows adding new configuration options

## Configuration

### `config/imgproxy.yml`
```yaml
endpoint: https://localhost:3000/
services:
  - name: pro
    endpoint: https://imgproxy-pro.com/
```

### With Ruby code

```ruby
Imgproxy.configure do |config|
  config.endpoint = 'https://localhost:3000/'
end

Imgproxy.configure(:pro) do |config|
  config.endpoint = 'https://imgproxy-pro.com/'
end
```

## Usage:

```ruby
Imgproxy.url_for(options, service: :pro) # => Generates url with https://imgproxy-pro.com/ endpoint
```

