### PR TITLE
Fix multiple assignments and parsing of raw

### DIFF
--- a/lib/imgproxy/config.rb
+++ b/lib/imgproxy/config.rb
@@ -100,7 +100,13 @@ module Imgproxy
     end
 
     def service(name)
-      services[name.to_sym] ||= ServiceConfig.new(services[:default].to_h)
+      services[name.to_sym] ||= ServiceConfig.new(
+        endpoint: endpoint,
+        key: key,
+        salt: salt,
+        signature_size: signature_size,
+      )
+
       yield services[name.to_sym] if block_given?
 
       services[name.to_sym]

--- a/lib/imgproxy/config.rb
+++ b/lib/imgproxy/config.rb
@@ -100,12 +100,7 @@ module Imgproxy
     end
 
     def service(name)
-      services[name.to_sym] ||= ServiceConfig.new(
-        endpoint: endpoint,
-        key: key,
-        salt: salt,
-        signature_size: signature_size,
-      )
+      services[name.to_sym] ||= services[:default].dup
 
       yield services[name.to_sym] if block_given?
 

--- a/lib/imgproxy/config.rb
+++ b/lib/imgproxy/config.rb
@@ -111,9 +111,7 @@ module Imgproxy
         s[:default] = ServiceConfig.new
 
         super.each do |name, data|
-          s[name.to_sym] = ServiceConfig.new(
-            s[:default].to_h.merge(data.symbolize_keys),
-          )
+          s[name.to_sym] = ServiceConfig.new(data.symbolize_keys)
         end
       end
     end

--- a/lib/imgproxy/config.rb
+++ b/lib/imgproxy/config.rb
@@ -43,6 +43,14 @@ module Imgproxy
       services: {},
     )
 
+    coerce_types use_short_options: :boolean,
+                 base64_encode_urls: :boolean,
+                 always_escape_plain_urls: :boolean,
+                 use_s3_urls: :boolean,
+                 use_gcs_urls: :boolean,
+                 gcs_bucket: :string,
+                 shrine_host: :string
+
     def endpoint
       service(:default).endpoint
     end

--- a/lib/imgproxy/service_config.rb
+++ b/lib/imgproxy/service_config.rb
@@ -36,6 +36,13 @@ module Imgproxy
       signature_size: 32,
     )
 
+    coerce_types endpoint: :string,
+                 key: :string,
+                 salt: :string,
+                 raw_key: :string,
+                 raw_salt: :string,
+                 signature_size: :integer
+
     alias_method :set_key, :key=
     alias_method :set_raw_key, :raw_key=
     alias_method :set_salt, :salt=


### PR DESCRIPTION
I found strange behavior when using ENV variables:

```ruby
$ IMGPROXY_KEY='1234567' irb

> require "bundler/setup"
> require "imgproxy"
> Imgproxy.config.key
=> "1234567"
> Imgproxy.config.service(:pro).key
=> "12345670"
```

It was because of merging `s[:default]` with `data`. Removing the merge helped. Finally setting both `key` and `raw_key` leads to such unexpected behavior, so also passed only `key` and `salt`.